### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,8 @@ jobs:
 
   publish:
     name: Publish
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'release'


### PR DESCRIPTION
Potential fix for [https://github.com/myd7349/SharpLSL/security/code-scanning/2](https://github.com/myd7349/SharpLSL/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the `publish` job in `.github/workflows/build.yml`. The recommended permissions are:
- `contents: write` for the `gh-release` step (which publishes a release and uploads files).
- Other permissions can likely be left unset unless you notice a specific need (e.g. `packages: write`, but not required for NuGet push since you're using a custom API key).
Place the `permissions` block directly under the `name: Publish` line (line 67). Avoid changing steps or environment variables unless specifically needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
